### PR TITLE
Added ToobitFuturesSymbol MinTradePrecision property

### DIFF
--- a/Toobit.Net/Objects/Models/ToobitExchangeInfo.cs
+++ b/Toobit.Net/Objects/Models/ToobitExchangeInfo.cs
@@ -195,6 +195,11 @@ namespace Toobit.Net.Objects.Models
         [JsonPropertyName("contractMultiplier")]
         public decimal? ContractMultiplier { get; set; }
         /// <summary>
+        /// ["<c>minTradePrecision</c>"] Minimal trade quantity step in contracts
+        /// </summary>
+        [JsonPropertyName("minTradePrecision")]
+        public decimal? MinTradePrecision { get; set; }
+        /// <summary>
         /// ["<c>riskLimits</c>"] Risk limits
         /// </summary>
         [JsonPropertyName("riskLimits")]


### PR DESCRIPTION
Added `MinTradePrecision` to the `ToobitFuturesSymbol` class. This is not explicitly shown in the documentation, but it is accessible via the API request.

`https://api.toobit.com/api/v1/exchangeInfo`

```json
...
        {
            "filters": [
                ...
            ],
            "exchangeId": "301",
            "symbol": "ETH-SWAP-USDT",
            "symbolName": "ETH-SWAP-USDT",
            "status": "TRADING",
            "baseAsset": "ETH-SWAP-USDT",
            "baseAssetPrecision": "0.001",
            "quoteAsset": "USDT",
            "quoteAssetPrecision": "0.01",
            "icebergAllowed": false,
            "inverse": false,
            "index": "ETH",
            "indexToken": "ETHUSDT",
            "marginToken": "USDT",
            "marginPrecision": "0.0001",
            "contractMultiplier": "0.01",
            "underlying": "ETH",
            "riskLimits": [
                ...
            ],
            "closingStartTime": "0",
            "closingEndTime": "0",
            "isRwa": false,
            "categories": [
                "Layer 1/2"
            ],
            "minTradePrecision": "0.1"
        },
...
```