### PR TITLE
Shared asset types

### DIFF
--- a/Toobit.Net/Clients/SpotApi/ToobitRestClientSpotApiShared.cs
+++ b/Toobit.Net/Clients/SpotApi/ToobitRestClientSpotApiShared.cs
@@ -99,21 +99,33 @@ namespace Toobit.Net.Clients.SpotApi
                 MinNotionalValue = s.MinNotionalFilter?.MinNotional,
                 QuantityStep = s.LotSizeFilter?.StepSize,
                 PriceStep = s.PriceFilter?.TickSize,
+                DisplayName = s.SymbolName,
                 QuoteAssetType = SharedAssetType.Crypto,
                 QuoteAssetSubType = SharedAssetSubType.StableCoin
             };
+
+            if (s.BaseAsset.Contains("GOOGL"))
+            {
+            }
 
             if (LibraryHelpers.IsStableCoin(s.BaseAsset))
             {
                 result.BaseAssetType = SharedAssetType.Crypto;
                 result.BaseAssetSubType = SharedAssetSubType.StableCoin;
             }
+            else if (LibraryHelpers.IsEquity(s.BaseAsset)
+                || (s.BaseAsset.EndsWith("X") && LibraryHelpers.IsEquity(s.BaseAsset.Substring(0, s.BaseAsset.Length - 1)))
+                || (s.BaseAsset.EndsWith("B") && LibraryHelpers.IsEquity(s.BaseAsset.Substring(0, s.BaseAsset.Length - 1))))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Equity;
+            }
             else if (LibraryHelpers.IsCommodity(s.BaseAsset))
             {
                 result.BaseAssetType = SharedAssetType.TradFi;
                 result.BaseAssetSubType = SharedAssetSubType.Commodity;
             }
-            else if (LibraryHelpers.IsCryptoCurrency(s.BaseAsset))
+            else
             {
                 result.BaseAssetType = SharedAssetType.Crypto;
             }

--- a/Toobit.Net/Clients/SpotApi/ToobitRestClientSpotApiShared.cs
+++ b/Toobit.Net/Clients/SpotApi/ToobitRestClientSpotApiShared.cs
@@ -104,18 +104,12 @@ namespace Toobit.Net.Clients.SpotApi
                 QuoteAssetSubType = SharedAssetSubType.StableCoin
             };
 
-            if (s.BaseAsset.Contains("GOOGL"))
-            {
-            }
-
             if (LibraryHelpers.IsStableCoin(s.BaseAsset))
             {
                 result.BaseAssetType = SharedAssetType.Crypto;
                 result.BaseAssetSubType = SharedAssetSubType.StableCoin;
             }
-            else if (LibraryHelpers.IsEquity(s.BaseAsset)
-                || (s.BaseAsset.EndsWith("X") && LibraryHelpers.IsEquity(s.BaseAsset.Substring(0, s.BaseAsset.Length - 1)))
-                || (s.BaseAsset.EndsWith("B") && LibraryHelpers.IsEquity(s.BaseAsset.Substring(0, s.BaseAsset.Length - 1))))
+            else if (LibraryHelpers.IsEquity(s.BaseAsset, ["X", "B"], []))
             {
                 result.BaseAssetType = SharedAssetType.TradFi;
                 result.BaseAssetSubType = SharedAssetSubType.Equity;

--- a/Toobit.Net/Clients/SpotApi/ToobitRestClientSpotApiShared.cs
+++ b/Toobit.Net/Clients/SpotApi/ToobitRestClientSpotApiShared.cs
@@ -69,7 +69,7 @@ namespace Toobit.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/Toobit.Net/Clients/SpotApi/ToobitRestClientSpotApiShared.cs
+++ b/Toobit.Net/Clients/SpotApi/ToobitRestClientSpotApiShared.cs
@@ -69,6 +69,7 @@ namespace Toobit.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -81,17 +82,43 @@ namespace Toobit.Net.Clients.SpotApi
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var resultData = HttpResult.Ok(result, result.Data.SpotSymbols.Where(x => x.Status == SymbolStatus.Trading).Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.Status == SymbolStatus.Trading)
+            var resultData =
+                 result.Data.SpotSymbols.Select(x => ParseSymbol(x))
+                .ToArray();
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(resultData, request));
+        }
+
+        private SharedSpotSymbol ParseSymbol(ToobitSpotSymbol s)
+        {
+            var result = new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.Status == SymbolStatus.Trading)
             {
                 MinTradeQuantity = s.LotSizeFilter?.MinQuantity,
                 MaxTradeQuantity = s.LotSizeFilter?.MaxQuantity,
                 MinNotionalValue = s.MinNotionalFilter?.MinNotional,
                 QuantityStep = s.LotSizeFilter?.StepSize,
-                PriceStep = s.PriceFilter?.TickSize
-            }).ToArray());
+                PriceStep = s.PriceFilter?.TickSize,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = SharedAssetSubType.StableCoin
+            };
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.Data!);
-            return resultData;
+            if (LibraryHelpers.IsStableCoin(s.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+                result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+            }
+            else if (LibraryHelpers.IsCommodity(s.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else if (LibraryHelpers.IsCryptoCurrency(s.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+            }
+
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)

--- a/Toobit.Net/Clients/UsdtFuturesApi/ToobitRestClientUsdtFuturesApiShared.cs
+++ b/Toobit.Net/Clients/UsdtFuturesApi/ToobitRestClientUsdtFuturesApiShared.cs
@@ -23,6 +23,8 @@ namespace Toobit.Net.Clients.UsdtFuturesApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(ToobitExchange.Metadata, this);
 
+        private static readonly HashSet<string> _fiatCurrencies = ["USD", "EUR"];
+
         #region Klines client
 
         GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(_exchangeName, false, true, true, 1000, false);
@@ -154,6 +156,7 @@ namespace Toobit.Net.Clients.UsdtFuturesApi
 
         #region Futures Symbol client
 
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -165,24 +168,65 @@ namespace Toobit.Net.Clients.UsdtFuturesApi
             if (!result.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
-            var data = result.Data.ContractSymbols.Where(x => x.Status == SymbolStatus.Trading);
-            var resultData = HttpResult.Ok(result, data.Select(s =>
-            new SharedFuturesSymbol(TradingMode.PerpetualLinear,
-            s.BaseAsset,
-            s.QuoteAsset,
-            s.Symbol,
-            s.Status == SymbolStatus.Trading)
+            var resultData =
+                 result.Data.ContractSymbols.Select(x => ParseSymbol(x))
+                .ToArray();
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(resultData, request));
+        }
+
+        private SharedFuturesSymbol ParseSymbol(ToobitFuturesSymbol s)
+        {
+            var result = new SharedFuturesSymbol(TradingMode.PerpetualLinear,
+                s.Underlying,
+                s.QuoteAsset,
+                s.Symbol,
+                s.Status == SymbolStatus.Trading)
             {
                 MinTradeQuantity = s.LotSizeFilter?.MinQuantity / s.ContractMultiplier,
                 MaxTradeQuantity = s.LotSizeFilter?.MaxQuantity / s.ContractMultiplier,
                 QuantityStep = s.LotSizeFilter?.StepSize / s.ContractMultiplier,
                 PriceStep = s.PriceFilter?.TickSize,
                 MinNotionalValue = s.MinNotionalFilter?.MinNotional,
-                ContractSize = s.ContractMultiplier
-            }).ToArray());
+                ContractSize = s.ContractMultiplier,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = SharedAssetSubType.StableCoin
+            };
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.Data!);
-            return resultData;
+            if (s.SymbolName.Contains("XAG"))
+            {
+            }
+
+            if (!s.IsRwa)
+            {
+                if (s.Categories.Contains("TradFi"))
+                {
+                    result.BaseAssetType = SharedAssetType.TradFi;
+                    result.BaseAssetSubType = SharedAssetSubType.Commodity;
+                }
+                else
+                {
+                    result.BaseAssetType = SharedAssetType.Crypto;
+                }
+            }
+            else
+            {
+                if (_fiatCurrencies.Contains(result.BaseAsset))
+                {
+                    result.BaseAssetType = SharedAssetType.Fiat;
+                }
+                else
+                {
+                    result.BaseAssetType = SharedAssetType.TradFi;
+                    if (LibraryHelpers.IsCommodity(result.BaseAsset))
+                        result.BaseAssetSubType = SharedAssetSubType.Commodity;
+                    else
+                        result.BaseAssetSubType = SharedAssetSubType.Equity;
+                }
+            }
+
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/Toobit.Net/Clients/UsdtFuturesApi/ToobitRestClientUsdtFuturesApiShared.cs
+++ b/Toobit.Net/Clients/UsdtFuturesApi/ToobitRestClientUsdtFuturesApiShared.cs
@@ -156,7 +156,7 @@ namespace Toobit.Net.Clients.UsdtFuturesApi
 
         #region Futures Symbol client
 
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {

--- a/Toobit.Net/Clients/UsdtFuturesApi/ToobitRestClientUsdtFuturesApiShared.cs
+++ b/Toobit.Net/Clients/UsdtFuturesApi/ToobitRestClientUsdtFuturesApiShared.cs
@@ -179,7 +179,7 @@ namespace Toobit.Net.Clients.UsdtFuturesApi
         private SharedFuturesSymbol ParseSymbol(ToobitFuturesSymbol s)
         {
             var result = new SharedFuturesSymbol(TradingMode.PerpetualLinear,
-                s.Underlying,
+                s.Underlying ?? s.BaseAsset,
                 s.QuoteAsset,
                 s.Symbol,
                 s.Status == SymbolStatus.Trading)
@@ -190,13 +190,10 @@ namespace Toobit.Net.Clients.UsdtFuturesApi
                 PriceStep = s.PriceFilter?.TickSize,
                 MinNotionalValue = s.MinNotionalFilter?.MinNotional,
                 ContractSize = s.ContractMultiplier,
+                DisplayName = s.SymbolName,
                 QuoteAssetType = SharedAssetType.Crypto,
                 QuoteAssetSubType = SharedAssetSubType.StableCoin
             };
-
-            if (s.SymbolName.Contains("XAG"))
-            {
-            }
 
             if (!s.IsRwa)
             {

--- a/Toobit.Net/Toobit.Net.csproj
+++ b/Toobit.Net/Toobit.Net.csproj
@@ -53,12 +53,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Toobit.Net/Toobit.Net.csproj
+++ b/Toobit.Net/Toobit.Net.csproj
@@ -53,10 +53,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models
Added DebuggerDisplay attributes to Shared models